### PR TITLE
Text matching consistency improvement

### DIFF
--- a/RoleplayingVoiceManager.cs
+++ b/RoleplayingVoiceManager.cs
@@ -7,6 +7,7 @@ using RoleplayingVoiceCore.AudioRecycler;
 using System.Numerics;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace RoleplayingVoiceCore {
     public class RoleplayingVoiceManager {
@@ -253,18 +254,28 @@ namespace RoleplayingVoiceCore {
         }
 
         private string TrimText(string text) {
-            string newText = text.Replace("XD", "ahahaha")
-            .Replace("lmao", "ahahaha")
-            .Replace("lol", "ahahaha")
-            .Replace("lmfao", "ahahaha")
-            .Replace("kek", "ahahaha")
-            .Replace("rotflmao", "ahahaha")
-            .Replace("rotflmfao", "ahahaha")
-            .Replace("lmao", "ahahaha")
-            .Replace(":D", ".")
-            .Replace(":3", ".")
-            .Replace(":P", ".")
-            .Replace("<3", "love");
+            string newText = text;
+            var wordReplacements = new Dictionary<string, string>
+            {
+                {"XD", "ahahaha" },
+                {"lmao", "ahahaha" },
+                {"lol", "ahahaha" },
+                {"lmfao", "ahahaha" },
+                {"kek", "ahahaha" },
+                {"kekw", "ahahaha" },
+                {"rotflmao", "ahahaha" },
+                {"rotflmfao", "ahahaha" },
+                {"lmao", "ahahaha" },
+                {":D", "." },
+                {":P", "." },
+                {":3", "." },
+                {"<3", "love" }
+            };
+            foreach (var word in wordReplacements)
+            {
+                // \b assert position at a word boundary
+                newText = Regex.Replace(newText, $"\b{word.Key}\b", word.Value, RegexOptions.IgnoreCase);
+            }
             foreach (char character in @"@#$%^&*()_+{}\/<>|`~".ToCharArray()) {
                 newText = newText.Replace(character + "", null);
             }

--- a/RoleplayingVoiceManager.cs
+++ b/RoleplayingVoiceManager.cs
@@ -273,8 +273,7 @@ namespace RoleplayingVoiceCore {
             };
             foreach (var word in wordReplacements)
             {
-                // \b assert position at a word boundary
-                newText = Regex.Replace(newText, $"\b{word.Key}\b", word.Value, RegexOptions.IgnoreCase);
+                newText = Regex.Replace(newText, $@"(?<=^|\s){word.Key}(?=\s|$)", word.Value, RegexOptions.IgnoreCase);
             }
             foreach (char character in @"@#$%^&*()_+{}\/<>|`~".ToCharArray()) {
                 newText = newText.Replace(character + "", null);


### PR DESCRIPTION
string.Replace() has a risk of matching and replacing text mid word, making result a mess