### PR TITLE
Fix Overlapping TTS Playback when different characters are speaking in turns

### DIFF
--- a/MediaManager.cs
+++ b/MediaManager.cs
@@ -22,6 +22,7 @@ namespace RoleplayingMediaCore {
         MediaObject _npcSound = null;
 
         public event EventHandler<MediaError> OnErrorReceived;
+        public event EventHandler<string> OnDiagnosticReceived;
         public event EventHandler OnCleanupTime;
         private IMediaGameObject _mainPlayer = null;
         private IMediaGameObject _camera;
@@ -181,6 +182,10 @@ namespace RoleplayingMediaCore {
             OnErrorReceived?.Invoke(this, new MediaError() { Exception = e.Exception });
         }
 
+        internal void TraceDiagnostic(string message) {
+            OnDiagnosticReceived?.Invoke(this, message);
+        }
+
         public async void PlayStream(IMediaGameObject playerObject, string audioPath, int delay = 0) {
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             Task.Run(() => {
@@ -270,13 +275,20 @@ namespace RoleplayingMediaCore {
 
                 }
                 try {
-                    if (_nativeGameAudio.ContainsKey(playerObject.Name)) {
+                    if (_nativeGameAudio.TryGetValue(playerObject.Name, out var nativeGameAudio)) {
                         _nativeAudioQueue.Clear();
-                        _nativeGameAudio[playerObject.Name].Invalidated = true;
-                        _nativeGameAudio[playerObject.Name].Stop();
+                        TraceDiagnostic($"NPC audio stop requested name='{playerObject.Name}' state={nativeGameAudio.PlaybackState} invalidated={nativeGameAudio.Invalidated}");
+                        nativeGameAudio.Invalidated = true;
+                        nativeGameAudio.Stop();
+                    } else {
+                        // This is intentionally logged for NPC audio only: if skipped dialogue
+                        // still overlaps, this tells maintainers whether the manager had a live
+                        // media object to stop when the dialogue state was cleared.
+                        TraceDiagnostic($"NPC audio stop requested but no active native audio was found name='{playerObject.Name}' activeNativeAudio={_nativeGameAudio.Count}");
                     }
-                } catch {
-
+                } catch (Exception e) {
+                    TraceDiagnostic($"NPC audio stop failed name='{playerObject.Name}' type={e.GetType().Name} message='{e.Message}'");
+                    OnErrorReceived?.Invoke(this, new MediaError() { Exception = e });
                 }
             }
         }

--- a/MediaManager.cs
+++ b/MediaManager.cs
@@ -110,11 +110,13 @@ namespace RoleplayingMediaCore {
             try {
                 if (playerObject != null) {
                     bool playbackQueued = false;
-                    if (_nativeGameAudio.ContainsKey(playerObject.Name)) {
-                        var mediaObject = _nativeGameAudio[playerObject.Name];
+                    if (_nativeGameAudio.TryGetValue(playerObject.Name, out var existingMediaObject)) {
                         if (!queuePlayback) {
-                            mediaObject.Stop();
-                        } else if (mediaObject.PlaybackState == PlaybackState.Playing) {
+                            // Stop the previous NPC media object before replacing the
+                            // dictionary entry so we do not lose the only handle capable
+                            // of halting stale dialogue playback.
+                            existingMediaObject.Stop();
+                        } else if (existingMediaObject.PlaybackState == PlaybackState.Playing) {
                             if (!_nativeAudioQueue.ContainsKey(playerObject.Name)) {
                                 _nativeAudioQueue.TryAdd(playerObject.Name, new Queue<WaveStream>());
                             }
@@ -130,11 +132,11 @@ namespace RoleplayingMediaCore {
                                 } catch { }
                             };
                             EventHandler<string> removalFunction = delegate {
-                                mediaObject.PlaybackStopped -= function;
-                                mediaObject.Invalidated = true;
+                                existingMediaObject.PlaybackStopped -= function;
+                                existingMediaObject.Invalidated = true;
                             };
-                            mediaObject.PlaybackStopped += function;
-                            mediaObject.PlaybackStopped += removalFunction;
+                            existingMediaObject.PlaybackStopped += function;
+                            existingMediaObject.PlaybackStopped += removalFunction;
                             playbackQueued = true;
                         }
                     }

--- a/MediaObject.cs
+++ b/MediaObject.cs
@@ -145,31 +145,37 @@ namespace RoleplayingMediaCore {
             });
         }
         private void DonePlayingCheck() {
+            var player = _player;
+            var wavePlayer = _wavePlayer;
+            if (player == null || wavePlayer == null) {
+                return;
+            }
+
             Stopwatch stopwatch = new Stopwatch();
-            Task.Run(async () => {
+            Task.Run(() => {
                 try {
                     Thread.Sleep(300);
-                    long lastPosition = _player?.Position ?? 0;
-                    while (true) {
-                        var player = _player;
-                        if (player == null) {
-                            break;
-                        }
+                    while (!Invalidated && !_disposed && ReferenceEquals(_player, player) && ReferenceEquals(_wavePlayer, wavePlayer)) {
                         if (player.Position > player.Length * 0.985f) {
                             if (!stopwatch.IsRunning) {
                                 stopwatch.Start();
                             }
                             if (stopwatch.ElapsedMilliseconds > 100) {
                                 Thread.Sleep(100);
-                                _wavePlayer?.Stop();
+                                // Stop() can run when dialogue advances before natural playback completion.
+                                // In that case this poll should exit quietly instead of touching disposed audio state.
+                                if (!Invalidated && !_disposed && ReferenceEquals(_wavePlayer, wavePlayer)) {
+                                    wavePlayer.Stop();
+                                }
                                 break;
                             }
                         } else {
                             stopwatch.Reset();
                         }
-                        lastPosition = player.Position;
                         Thread.Sleep(100);
                     }
+                } catch (ObjectDisposedException) {
+                    // Stop()/Dispose() owns cleanup when playback is interrupted, such as skipping NPC dialogue.
                 } catch (Exception e) { OnErrorReceived?.Invoke(this, new MediaError() { Exception = e }); }
             });
         }

--- a/MediaObject.cs
+++ b/MediaObject.cs
@@ -265,21 +265,29 @@ namespace RoleplayingMediaCore {
         public void Stop() {
             Volume = 0;
             EndLooping();
-            if (_wavePlayer != null) {
+            var wavePlayer = _wavePlayer;
+            var player = _player;
+            if (_soundType == SoundType.NPC) {
+                _parent?.TraceDiagnostic($"NPC media stop entered name='{_playerObject?.Name}' hasWavePlayer={wavePlayer != null} hasStream={player != null} state={PlaybackState} invalidated={Invalidated} disposed={_disposed}");
+            }
+
+            if (wavePlayer != null) {
                 try {
-                    if (_wavePlayer != null) {
-                        try {
-                            _wavePlayer?.Stop();
-                            _wavePlayer?.Dispose();
-                        } catch {
-                            PlaybackStopped?.Invoke(this, "OK");
-                        }
+                    wavePlayer.Stop();
+                    wavePlayer.Dispose();
+                    if (_soundType == SoundType.NPC) {
+                        _parent?.TraceDiagnostic($"NPC media stop completed name='{_playerObject?.Name}'");
                     }
                 } catch (Exception e) {
+                    if (_soundType == SoundType.NPC) {
+                        _parent?.TraceDiagnostic($"NPC media stop failed name='{_playerObject?.Name}' type={e.GetType().Name} message='{e.Message}'");
+                    }
                     OnErrorReceived?.Invoke(this, new MediaError() { Exception = e });
                     PlaybackStopped?.Invoke(this, "OK");
                 }
-                _wavePlayer = null;
+                if (ReferenceEquals(_wavePlayer, wavePlayer)) {
+                    _wavePlayer = null;
+                }
             } else {
                 PlaybackStopped?.Invoke(this, "OK");
             }
@@ -288,8 +296,16 @@ namespace RoleplayingMediaCore {
                     _vlcPlayer?.Stop();
                 } catch (Exception e) { OnErrorReceived?.Invoke(this, new MediaError() { Exception = e }); }
             }
-            try { _player?.Dispose(); } catch { }
-            _player = null;
+            try {
+                player?.Dispose();
+            } catch (Exception e) {
+                if (_soundType == SoundType.NPC) {
+                    _parent?.TraceDiagnostic($"NPC media stream dispose failed name='{_playerObject?.Name}' type={e.GetType().Name} message='{e.Message}'");
+                }
+            }
+            if (ReferenceEquals(_player, player)) {
+                _player = null;
+            }
             Volume = 0;
             Invalidated = true;
         }

--- a/MediaObject.cs
+++ b/MediaObject.cs
@@ -292,7 +292,7 @@ namespace RoleplayingMediaCore {
                 player = _player;
                 vlcPlayer = _vlcPlayer;
                 vlc = libVLC;
-                shouldNotifyStopped = wavePlayer == null && vlcPlayer == null;
+                shouldNotifyStopped = wavePlayer == null;
 
                 if (isNpc) {
                     _parent?.TraceDiagnostic($"NPC media stop entered name='{objectName}' hasWavePlayer={wavePlayer != null} hasStream={player != null} hasVlcPlayer={vlcPlayer != null} state={playbackState} invalidated={Invalidated} disposed={_disposed}");

--- a/MediaObject.cs
+++ b/MediaObject.cs
@@ -273,69 +273,35 @@ namespace RoleplayingMediaCore {
 
         private void StopAndDisposePlayback(bool disposeVideoResources) {
             bool shouldNotifyStopped = false;
+            bool isNpc;
+            string objectName;
+            IWavePlayer wavePlayer;
+            WaveStream player;
+            MediaPlayer vlcPlayer;
+            LibVLC vlc;
 
             lock (_playbackLifecycleLock) {
-                var isNpc = _soundType == SoundType.NPC;
-                var objectName = _playerObject?.Name;
+                isNpc = _soundType == SoundType.NPC;
+                objectName = _playerObject?.Name;
                 var playbackState = PlaybackState;
 
                 try { Volume = 0; } catch { }
                 EndLooping();
 
-                var wavePlayer = _wavePlayer;
-                var player = _player;
-                var vlcPlayer = _vlcPlayer;
-                var vlc = libVLC;
+                wavePlayer = _wavePlayer;
+                player = _player;
+                vlcPlayer = _vlcPlayer;
+                vlc = libVLC;
                 shouldNotifyStopped = wavePlayer == null && vlcPlayer == null;
 
                 if (isNpc) {
                     _parent?.TraceDiagnostic($"NPC media stop entered name='{objectName}' hasWavePlayer={wavePlayer != null} hasStream={player != null} hasVlcPlayer={vlcPlayer != null} state={playbackState} invalidated={Invalidated} disposed={_disposed}");
                 }
 
-                // Keep the captured playback handles alive until Stop() has run.
-                // Cleanup paths can overwrite maps and fields, but they must not
-                // drop the last object capable of halting audio first.
+                // Capture the handles before clearing fields. The local handles are
+                // now responsible for shutdown, so dictionary replacement or cleanup
+                // cannot drop the last object capable of stopping stale playback.
                 Invalidated = true;
-
-                if (wavePlayer != null) {
-                    try {
-                        wavePlayer.Stop();
-                        wavePlayer.Dispose();
-                        if (isNpc) {
-                            _parent?.TraceDiagnostic($"NPC media wave stop completed name='{objectName}'");
-                        }
-                    } catch (Exception e) {
-                        if (isNpc) {
-                            _parent?.TraceDiagnostic($"NPC media wave stop failed name='{objectName}' type={e.GetType().Name} message='{e.Message}'");
-                        }
-                        OnErrorReceived?.Invoke(this, new MediaError() { Exception = e });
-                        shouldNotifyStopped = true;
-                    }
-                }
-
-                if (vlcPlayer != null) {
-                    try {
-                        vlcPlayer.Stop();
-                        if (disposeVideoResources) {
-                            vlcPlayer.Dispose();
-                        }
-                    } catch (Exception e) {
-                        OnErrorReceived?.Invoke(this, new MediaError() { Exception = e });
-                        shouldNotifyStopped = true;
-                    }
-                }
-
-                try {
-                    player?.Dispose();
-                } catch (Exception e) {
-                    if (isNpc) {
-                        _parent?.TraceDiagnostic($"NPC media stream dispose failed name='{objectName}' type={e.GetType().Name} message='{e.Message}'");
-                    }
-                }
-
-                if (disposeVideoResources) {
-                    try { vlc?.Dispose(); } catch { }
-                }
 
                 if (ReferenceEquals(_wavePlayer, wavePlayer)) {
                     _wavePlayer = null;
@@ -351,6 +317,46 @@ namespace RoleplayingMediaCore {
                 }
 
                 try { Volume = 0; } catch { }
+            }
+
+            if (wavePlayer != null) {
+                try {
+                    wavePlayer.Stop();
+                    wavePlayer.Dispose();
+                    if (isNpc) {
+                        _parent?.TraceDiagnostic($"NPC media wave stop completed name='{objectName}'");
+                    }
+                } catch (Exception e) {
+                    if (isNpc) {
+                        _parent?.TraceDiagnostic($"NPC media wave stop failed name='{objectName}' type={e.GetType().Name} message='{e.Message}'");
+                    }
+                    OnErrorReceived?.Invoke(this, new MediaError() { Exception = e });
+                    shouldNotifyStopped = true;
+                }
+            }
+
+            if (vlcPlayer != null) {
+                try {
+                    vlcPlayer.Stop();
+                    if (disposeVideoResources) {
+                        vlcPlayer.Dispose();
+                    }
+                } catch (Exception e) {
+                    OnErrorReceived?.Invoke(this, new MediaError() { Exception = e });
+                    shouldNotifyStopped = true;
+                }
+            }
+
+            try {
+                player?.Dispose();
+            } catch (Exception e) {
+                if (isNpc) {
+                    _parent?.TraceDiagnostic($"NPC media stream dispose failed name='{objectName}' type={e.GetType().Name} message='{e.Message}'");
+                }
+            }
+
+            if (disposeVideoResources) {
+                try { vlc?.Dispose(); } catch { }
             }
 
             if (shouldNotifyStopped) {

--- a/MediaObject.cs
+++ b/MediaObject.cs
@@ -67,6 +67,7 @@ namespace RoleplayingMediaCore {
         private bool _vlcWasAbleToStart;
         private float _volumeOffset;
         private bool _disposed;
+        private readonly object _playbackLifecycleLock = new object();
 
         public MediaObject(MediaManager parent, IMediaGameObject playerObject, IMediaGameObject camera,
             SoundType soundType, string soundPath, string libVLCPath, bool spatialAllowed) {
@@ -257,60 +258,104 @@ namespace RoleplayingMediaCore {
                 try {
                     _loopStream.EnableLooping = false;
                     _loopStream?.Dispose();
+                    _loopStream = null;
                 } catch {
 
                 }
             }
         }
         public void Stop() {
-            Volume = 0;
-            EndLooping();
-            var wavePlayer = _wavePlayer;
-            var player = _player;
-            if (_soundType == SoundType.NPC) {
-                _parent?.TraceDiagnostic($"NPC media stop entered name='{_playerObject?.Name}' hasWavePlayer={wavePlayer != null} hasStream={player != null} state={PlaybackState} invalidated={Invalidated} disposed={_disposed}");
-            }
-
-            if (wavePlayer != null) {
-                try {
-                    wavePlayer.Stop();
-                    wavePlayer.Dispose();
-                    if (_soundType == SoundType.NPC) {
-                        _parent?.TraceDiagnostic($"NPC media stop completed name='{_playerObject?.Name}'");
-                    }
-                } catch (Exception e) {
-                    if (_soundType == SoundType.NPC) {
-                        _parent?.TraceDiagnostic($"NPC media stop failed name='{_playerObject?.Name}' type={e.GetType().Name} message='{e.Message}'");
-                    }
-                    OnErrorReceived?.Invoke(this, new MediaError() { Exception = e });
-                    PlaybackStopped?.Invoke(this, "OK");
-                }
-                if (ReferenceEquals(_wavePlayer, wavePlayer)) {
-                    _wavePlayer = null;
-                }
-            } else {
-                PlaybackStopped?.Invoke(this, "OK");
-            }
-            if (_vlcPlayer != null) {
-                try {
-                    _vlcPlayer?.Stop();
-                } catch (Exception e) { OnErrorReceived?.Invoke(this, new MediaError() { Exception = e }); }
-            }
-            try {
-                player?.Dispose();
-            } catch (Exception e) {
-                if (_soundType == SoundType.NPC) {
-                    _parent?.TraceDiagnostic($"NPC media stream dispose failed name='{_playerObject?.Name}' type={e.GetType().Name} message='{e.Message}'");
-                }
-            }
-            if (ReferenceEquals(_player, player)) {
-                _player = null;
-            }
-            Volume = 0;
-            Invalidated = true;
+            StopAndDisposePlayback(false);
         }
         public void LoopEarly() {
             _loopStream?.LoopEarly();
+        }
+
+        private void StopAndDisposePlayback(bool disposeVideoResources) {
+            bool shouldNotifyStopped = false;
+
+            lock (_playbackLifecycleLock) {
+                var isNpc = _soundType == SoundType.NPC;
+                var objectName = _playerObject?.Name;
+                var playbackState = PlaybackState;
+
+                try { Volume = 0; } catch { }
+                EndLooping();
+
+                var wavePlayer = _wavePlayer;
+                var player = _player;
+                var vlcPlayer = _vlcPlayer;
+                var vlc = libVLC;
+                shouldNotifyStopped = wavePlayer == null && vlcPlayer == null;
+
+                if (isNpc) {
+                    _parent?.TraceDiagnostic($"NPC media stop entered name='{objectName}' hasWavePlayer={wavePlayer != null} hasStream={player != null} hasVlcPlayer={vlcPlayer != null} state={playbackState} invalidated={Invalidated} disposed={_disposed}");
+                }
+
+                // Keep the captured playback handles alive until Stop() has run.
+                // Cleanup paths can overwrite maps and fields, but they must not
+                // drop the last object capable of halting audio first.
+                Invalidated = true;
+
+                if (wavePlayer != null) {
+                    try {
+                        wavePlayer.Stop();
+                        wavePlayer.Dispose();
+                        if (isNpc) {
+                            _parent?.TraceDiagnostic($"NPC media wave stop completed name='{objectName}'");
+                        }
+                    } catch (Exception e) {
+                        if (isNpc) {
+                            _parent?.TraceDiagnostic($"NPC media wave stop failed name='{objectName}' type={e.GetType().Name} message='{e.Message}'");
+                        }
+                        OnErrorReceived?.Invoke(this, new MediaError() { Exception = e });
+                        shouldNotifyStopped = true;
+                    }
+                }
+
+                if (vlcPlayer != null) {
+                    try {
+                        vlcPlayer.Stop();
+                        if (disposeVideoResources) {
+                            vlcPlayer.Dispose();
+                        }
+                    } catch (Exception e) {
+                        OnErrorReceived?.Invoke(this, new MediaError() { Exception = e });
+                        shouldNotifyStopped = true;
+                    }
+                }
+
+                try {
+                    player?.Dispose();
+                } catch (Exception e) {
+                    if (isNpc) {
+                        _parent?.TraceDiagnostic($"NPC media stream dispose failed name='{objectName}' type={e.GetType().Name} message='{e.Message}'");
+                    }
+                }
+
+                if (disposeVideoResources) {
+                    try { vlc?.Dispose(); } catch { }
+                }
+
+                if (ReferenceEquals(_wavePlayer, wavePlayer)) {
+                    _wavePlayer = null;
+                }
+                if (ReferenceEquals(_player, player)) {
+                    _player = null;
+                }
+                if (disposeVideoResources && ReferenceEquals(_vlcPlayer, vlcPlayer)) {
+                    _vlcPlayer = null;
+                }
+                if (disposeVideoResources && ReferenceEquals(libVLC, vlc)) {
+                    libVLC = null;
+                }
+
+                try { Volume = 0; } catch { }
+            }
+
+            if (shouldNotifyStopped) {
+                PlaybackStopped?.Invoke(this, "OK");
+            }
         }
 
         public async void Play(WaveStream soundPath, float volume, int delay, bool useSmbPitch,
@@ -734,12 +779,7 @@ namespace RoleplayingMediaCore {
             }
             _disposed = true;
             _parent.OnCleanupTime -= _parent_OnCleanupTime;
-            Stop();
-            Volume = 0;
-            try { _vlcPlayer?.Dispose(); } catch { }
-            _vlcPlayer = null;
-            try { libVLC?.Dispose(); } catch { }
-            libVLC = null;
+            StopAndDisposePlayback(true);
         }
     }
     public enum SoundType {


### PR DESCRIPTION
Intent: harden media playback cleanup so interrupted NPC audio is stopped reliably and disposal races do not throw.

- Guards DonePlayingCheck() against player/stream disposal races.
- Centralizes MediaObject stop/dispose cleanup so playback handles are captured before fields are cleared.
- Stops existing NPC media before replacing its dictionary entry, preserving the only handle able to halt stale playback.
- Adds focused NPC audio stop diagnostics for found/missing/failed stop paths.
- Uses TryGetValue() in NPC media stop/replacement paths to avoid dictionary lookup races.

Supports: https://github.com/Sebane1/RoleplayingVoiceDalamud/pull/61